### PR TITLE
Minor updates

### DIFF
--- a/export_device_config.py
+++ b/export_device_config.py
@@ -7,10 +7,11 @@ import json
 from colorama import init
 from termcolor import colored
 from datetime import datetime
+from distutils.util import strtobool
 
 # Disable SSL warnings. Not needed in production environments with valid certificates
 # (REMOVE if you are not sure of its purpose)
-urllib3.disable_warnings()
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 # use Colorama to make Termcolor work on Windows too
 init(autoreset=True)
@@ -30,7 +31,7 @@ def export_device_config(token: str, ENV: dict):
             f"{ENV['BASE_URL']}{DEVICE_CONFIG_URL}",
             headers=headers,
             data=None,
-            verify=bool(ENV["SSL_CERTIFICATE"]),
+            verify=True if strtobool(ENV["SSL_CERTIFICATE"]) else False,
         )
         response.raise_for_status()
         print(colored("export_device_config:", "magenta"))

--- a/export_device_config.py
+++ b/export_device_config.py
@@ -5,7 +5,7 @@ import requests
 from requests.packages import urllib3
 import json
 from colorama import init
-from termcolor import colored
+from termcolor import cprint
 from datetime import datetime
 from distutils.util import strtobool
 
@@ -34,12 +34,10 @@ def export_device_config(token: str, ENV: dict):
             verify=True if strtobool(ENV["SSL_CERTIFICATE"]) else False,
         )
         response.raise_for_status()
-        print(colored("export_device_config:", "magenta"))
-        print(
-            colored(
-                "The request was successful. The result is contained in the response body.\n",
-                "green",
-            )
+        cprint("export_device_config:", "magenta")
+        cprint(
+            "The request was successful. The result is contained in the response body.\n",
+            "green",
         )
 
         device_configs = response.json()["response"]
@@ -59,13 +57,12 @@ def export_device_config(token: str, ENV: dict):
             # Create a config file
             with open(os.path.join(DIR, cfg_file_name), "w") as config_file:
                 config_file.write(cfg)
-                print(
-                    colored(
-                        f"'{cfg_file_name}' config file is created successfully!",
-                        "cyan",
-                    )
+                cprint(
+                    f"'{cfg_file_name}' config file is created successfully!",
+                    "cyan",
                 )
+
         print("\n")
 
     except requests.exceptions.HTTPError as err:
-        raise SystemExit(colored(err, "red"))
+        raise SystemExit(cprint(err, "red"))

--- a/export_device_list.py
+++ b/export_device_list.py
@@ -6,7 +6,7 @@ import datetime
 import time
 import webbrowser as xlsxviewer
 from colorama import init
-from termcolor import colored
+from termcolor import cprint
 
 # use Colorama to make Termcolor work on Windows too
 init(autoreset=True)
@@ -186,18 +186,14 @@ def export_device_list(device_list: list, ENV: dict):
     while True:
         try:
             workbook.close()
-            print(colored("export_device_list:", "magenta"))
-            print(
-                colored(
-                    f"'{workbook_title}' Excel file is created successfully!", "cyan"
-                )
-            )
-            print(colored(f"Opening '{workbook_title}', please wait ...\n", "cyan"))
+            cprint("export_device_list:", "magenta")
+            cprint(f"'{workbook_title}' Excel file is created successfully!", "cyan")
+            cprint(f"Opening '{workbook_title}', please wait ...\n", "cyan")
             time.sleep(1)
             xlsxviewer.open(os.path.abspath(workbook_title))
         except xlsxwriter.exceptions.FileCreateError as err:
             raise SystemExit(
-                colored(
+                cprint(
                     f"Exception caught in workbook.close(): {err}\n"
                     f"Please close '{workbook_title}' file if it is already open in Microsoft Excel or in use by another program.",
                     "red",

--- a/get_auth_token.py
+++ b/get_auth_token.py
@@ -6,10 +6,11 @@ from requests.packages import urllib3
 import json
 from colorama import init
 from termcolor import colored
+from distutils.util import strtobool
 
 # Disable SSL warnings. Not needed in production environments with valid certificates
 # (REMOVE if you are not sure of its purpose)
-urllib3.disable_warnings()
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 # use Colorama to make Termcolor work on Windows too
 init(autoreset=True)
@@ -38,7 +39,7 @@ def get_auth_token(ENV: dict) -> str:
             auth=HTTPBasicAuth(ENV["USERNAME"], ENV["PASSWORD"]),
             headers=headers,
             data=None,
-            verify=bool(ENV["SSL_CERTIFICATE"]),
+            verify=True if strtobool(ENV["SSL_CERTIFICATE"]) else False,
         )
 
         response.raise_for_status()

--- a/get_auth_token.py
+++ b/get_auth_token.py
@@ -5,7 +5,7 @@ from requests.auth import HTTPBasicAuth
 from requests.packages import urllib3
 import json
 from colorama import init
-from termcolor import colored
+from termcolor import cprint
 from distutils.util import strtobool
 
 # Disable SSL warnings. Not needed in production environments with valid certificates
@@ -43,8 +43,8 @@ def get_auth_token(ENV: dict) -> str:
         )
 
         response.raise_for_status()
-        print(colored("get_auth_token:", "magenta"))
-        print(colored("Successful Token Generation.\n", "green"))
+        cprint("get_auth_token:", "magenta")
+        cprint("Successful Token Generation.\n", "green")
         return response.json()["Token"]
     except requests.exceptions.HTTPError as err:
-        raise SystemExit(colored(err, "red"))
+        raise SystemExit(cprint(err, "red"))

--- a/get_device_list.py
+++ b/get_device_list.py
@@ -4,7 +4,7 @@ import requests
 from requests.packages import urllib3
 import json
 from colorama import init
-from termcolor import colored
+from termcolor import cprint
 from distutils.util import strtobool
 
 # Disable SSL warnings. Not needed in production environments with valid certificates
@@ -45,13 +45,11 @@ def get_device_list(token: str, ENV: dict) -> list:
             verify=True if strtobool(ENV["SSL_CERTIFICATE"]) else False,
         )
         response.raise_for_status()
-        print(colored("get_device_list:", "magenta"))
-        print(
-            colored(
-                "The request was successful. The result is contained in the response body.\n",
-                "green",
-            )
+        cprint("get_device_list:", "magenta")
+        cprint(
+            "The request was successful. The result is contained in the response body.\n",
+            "green",
         )
         return response.json()["response"]
     except requests.exceptions.HTTPError as err:
-        raise SystemExit(colored(err, "red"))
+        raise SystemExit(cprint(err, "red"))

--- a/get_device_list.py
+++ b/get_device_list.py
@@ -5,10 +5,11 @@ from requests.packages import urllib3
 import json
 from colorama import init
 from termcolor import colored
+from distutils.util import strtobool
 
 # Disable SSL warnings. Not needed in production environments with valid certificates
 # (REMOVE if you are not sure of its purpose)
-urllib3.disable_warnings()
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 # use Colorama to make Termcolor work on Windows too
 init(autoreset=True)
@@ -41,7 +42,7 @@ def get_device_list(token: str, ENV: dict) -> list:
             f"{ENV['BASE_URL']}{DEVICE_LIST_URL}",
             headers=headers,
             data=None,
-            verify=bool(ENV["SSL_CERTIFICATE"]),
+            verify=True if strtobool(ENV["SSL_CERTIFICATE"]) else False,
         )
         response.raise_for_status()
         print(colored("get_device_list:", "magenta"))

--- a/get_network_health.py
+++ b/get_network_health.py
@@ -7,7 +7,7 @@ import json
 import time
 import matplotlib.pyplot as plt
 from colorama import init
-from termcolor import colored
+from termcolor import cprint
 from datetime import datetime
 from distutils.util import strtobool
 
@@ -47,12 +47,10 @@ def get_network_health(token: str, ENV: dict):
             verify=True if strtobool(ENV["SSL_CERTIFICATE"]) else False,
         )
         response.raise_for_status()
-        print(colored("get_network_health:", "magenta"))
-        print(
-            colored(
-                "The request was successful. The result is contained in the response body.\n",
-                "green",
-            )
+        cprint("get_network_health:", "magenta")
+        cprint(
+            "The request was successful. The result is contained in the response body.\n",
+            "green",
         )
 
         health_distribution = response.json()["healthDistirubution"]
@@ -97,12 +95,7 @@ def get_network_health(token: str, ENV: dict):
         ax2.grid(True)
         # Save plot to net_health/*.jpg
         plt.savefig(NET_HEALTH_FIG, dpi=300)
-        print(
-            colored(
-                f"Please check '{NET_HEALTH_FIG}'",
-                "cyan",
-            )
-        )
+        cprint(f"Please check '{NET_HEALTH_FIG}'", "cyan")
 
     except requests.exceptions.HTTPError as err:
-        raise SystemExit(colored(err, "red"))
+        raise SystemExit(cprint(err, "red"))

--- a/get_network_health.py
+++ b/get_network_health.py
@@ -9,10 +9,11 @@ import matplotlib.pyplot as plt
 from colorama import init
 from termcolor import colored
 from datetime import datetime
+from distutils.util import strtobool
 
 # Disable SSL warnings. Not needed in production environments with valid certificates
 # (REMOVE if you are not sure of its purpose)
-urllib3.disable_warnings()
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 # use Colorama to make Termcolor work on Windows too
 init(autoreset=True)
@@ -43,7 +44,7 @@ def get_network_health(token: str, ENV: dict):
             f"{ENV['BASE_URL']}{NETWORK_HEALTH_URL}",
             headers=headers,
             data=None,
-            verify=bool(ENV["SSL_CERTIFICATE"]),
+            verify=True if strtobool(ENV["SSL_CERTIFICATE"]) else False,
         )
         response.raise_for_status()
         print(colored("get_network_health:", "magenta"))


### PR DESCRIPTION
1. Fix logic for verifying param in request.
2. Use `cprint(message, color)` instead of `print(colored(message, color))`.
3. Set `urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)` to disable SSL warnings only.